### PR TITLE
Update argument in CGBitmapContextCreate to silence warning.

### DIFF
--- a/UIView+ColorOfPoint/UIView+ColorOfPoint.m
+++ b/UIView+ColorOfPoint/UIView+ColorOfPoint.m
@@ -15,7 +15,7 @@
 
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 
-	CGContextRef context = CGBitmapContextCreate(pixel, 1, 1, 8, 4, colorSpace, kCGImageAlphaPremultipliedLast);
+	CGContextRef context = CGBitmapContextCreate(pixel, 1, 1, 8, 4, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
 
 	CGContextTranslateCTM(context, -point.x, -point.y);
 


### PR DESCRIPTION
Changes the type of the last argument to a call to CGBitmapContextCreate
(without changing the actual value passed in the argument) to silence
a compiler warning in Xcode 5 DP.
